### PR TITLE
bug: #116 - Bug backtest fix

### DIFF
--- a/.claude/commands/conditional_docs.md
+++ b/.claude/commands/conditional_docs.md
@@ -500,3 +500,15 @@ This prompt helps you determine what documentation you should read based on the 
     - When troubleshooting backtest failures during initialization or execution
     - When working with ISO format datetime parsing and timezone conversion
     - When implementing consistent timezone handling across datetime operations
+
+- app_docs/feature-f58bdd9c-backtest-conditions-format-fix.md
+  - Conditions:
+    - When troubleshooting "AttributeError: 'list' object has no attribute 'get'" errors in backtest execution
+    - When working with strategy conditions data structure in backtest_executor.py
+    - When implementing backward compatibility for legacy vs current condition formats
+    - When working with condition section types (long_entry, short_entry, long_exit, short_exit)
+    - When troubleshooting backtests failing immediately after loading strategy data
+    - When debugging condition extraction or filtering in _execute_backtest method
+    - When implementing format detection for list vs dictionary condition data
+    - When working with StrategyCondition model or strategy persistence formats
+    - When migrating condition data structures or handling mixed condition formats

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
         "@playwright/mcp@latest",
         "--isolated",
         "--config",
-        "/home/ubuntu/algotrading/trees/4620e8ed/playwright-mcp-config.json"
+        "/home/ubuntu/algotrading/trees/f58bdd9c/playwright-mcp-config.json"
       ]
     }
   }

--- a/app/server/core/backtest_executor.py
+++ b/app/server/core/backtest_executor.py
@@ -491,11 +491,22 @@ class BacktestExecutor:
             full_equity_curve = [initial_balance]
 
             # Get strategy conditions
-            conditions = strategy.get("conditions", {}) or {}
-            long_entry_conditions = conditions.get("long_entry", []) or []
-            short_entry_conditions = conditions.get("short_entry", []) or []
-            _long_exit_conditions = conditions.get("long_exit", []) or []  # noqa: F841
-            _short_exit_conditions = conditions.get("short_exit", []) or []  # noqa: F841
+            # Conditions can be a list of condition objects with 'section' field
+            # or a dict with 'long_entry'/'short_entry' keys
+            conditions = strategy.get("conditions", []) or []
+
+            if isinstance(conditions, list):
+                # New format: list of condition objects with 'section' field
+                long_entry_conditions = [c for c in conditions if c.get("section") == "long_entry"]
+                short_entry_conditions = [c for c in conditions if c.get("section") == "short_entry"]
+                _long_exit_conditions = [c for c in conditions if c.get("section") == "long_exit"]  # noqa: F841
+                _short_exit_conditions = [c for c in conditions if c.get("section") == "short_exit"]  # noqa: F841
+            else:
+                # Legacy format: dict with entry type keys
+                long_entry_conditions = conditions.get("long_entry", []) or []
+                short_entry_conditions = conditions.get("short_entry", []) or []
+                _long_exit_conditions = conditions.get("long_exit", []) or []  # noqa: F841
+                _short_exit_conditions = conditions.get("short_exit", []) or []  # noqa: F841
 
             # Process candles
             for i, candle in enumerate(candles):

--- a/app/server/tests/test_backtest_executor.py
+++ b/app/server/tests/test_backtest_executor.py
@@ -1407,8 +1407,6 @@ class TestConditionFormatHandling:
 
     def test_execute_backtest_with_empty_conditions_list(self, executor, mock_supabase):
         """Test graceful handling of empty conditions."""
-        from unittest.mock import patch
-
         # Mock the database responses with empty conditions list
         mock_supabase.table.return_value.select.return_value.eq.return_value.execute.side_effect = [
             # Backtest lookup

--- a/app_docs/agentic_kpis.md
+++ b/app_docs/agentic_kpis.md
@@ -8,13 +8,13 @@ Summary metrics across all ADW runs.
 
 | Metric            | Value          | Last Updated             |
 | ----------------- | -------------- | ------------------------ |
-| Current Streak    | 33             | Fri Jan 23 03:03:11 2026 |
-| Longest Streak    | 33             | Fri Jan 23 03:03:11 2026 |
-| Total Plan Size   | 8955 lines     | Fri Jan 23 03:03:11 2026 |
-| Largest Plan Size | 411 lines      | Fri Jan 23 03:03:11 2026 |
-| Total Diff Size   | 55568 lines    | Fri Jan 23 03:03:11 2026 |
-| Largest Diff Size | 3873 lines     | Fri Jan 23 03:03:11 2026 |
-| Average Presence  | 1.00           | Fri Jan 23 03:03:11 2026 |
+| Current Streak    | 34             | Fri Jan 23 12:11:44 2026 |
+| Longest Streak    | 34             | Fri Jan 23 12:11:44 2026 |
+| Total Plan Size   | 9046 lines     | Fri Jan 23 12:11:44 2026 |
+| Largest Plan Size | 411 lines      | Fri Jan 23 12:11:44 2026 |
+| Total Diff Size   | 55974 lines    | Fri Jan 23 12:11:44 2026 |
+| Largest Diff Size | 3873 lines     | Fri Jan 23 12:11:44 2026 |
+| Average Presence  | 1.00           | Fri Jan 23 12:11:44 2026 |
 
 ## ADW KPIs
 
@@ -55,3 +55,4 @@ Detailed metrics for individual ADW workflow runs.
 | 2026-01-22 | 632a538d | 108          | /feature    | 1        | 327               | 2564/44/18                      | Thu Jan 22 13:44:07 UTC 2026 | Thu Jan 22 13:44:07 UTC 2026 |
 | 2026-01-23 | 50dfaeee | 112          | /feature    | 1        | 392               | 2301/22/13                      | Fri Jan 23 00:25:14 UTC 2026 | Fri Jan 23 00:25:14 UTC 2026 |
 | 2026-01-23 | 4620e8ed | 114          | /bug        | 1        | 136               | 1719/1263/52                    | Fri Jan 23 03:03:11 UTC 2026 | Fri Jan 23 03:03:11 UTC 2026 |
+| 2026-01-23 | f58bdd9c | 116          | /bug        | 1        | 91                | 399/7/7                         | Fri Jan 23 12:11:44 UTC 2026 | Fri Jan 23 12:11:44 UTC 2026 |

--- a/app_docs/feature-f58bdd9c-backtest-conditions-format-fix.md
+++ b/app_docs/feature-f58bdd9c-backtest-conditions-format-fix.md
@@ -1,0 +1,59 @@
+# Backtest Conditions Data Structure Fix
+
+**ADW ID:** f58bdd9c
+**Date:** 2026-01-23
+**Specification:** specs/issue-116-adw-f58bdd9c-sdlc_planner-backtest-conditions-data-structure.md
+
+## Overview
+
+Fixed a critical bug in the backtest executor that caused all backtests to fail with `AttributeError: 'list' object has no attribute 'get'`. The executor now correctly handles both the legacy dictionary format and the current list-based format for strategy conditions, maintaining backward compatibility while supporting the modern data structure.
+
+## What Was Built
+
+- Updated `BacktestExecutor._execute_backtest()` to detect and handle both condition data formats
+- Added comprehensive unit tests for all condition format scenarios
+- Ensured zero regression across existing backtest functionality
+
+## Technical Implementation
+
+### Files Modified
+
+- `app/server/core/backtest_executor.py`: Added format detection logic in `_execute_backtest()` method (lines 494-509) to handle both list and dictionary condition formats
+- `app/server/tests/test_backtest_executor.py`: Added `TestConditionFormatHandling` test class with 4 comprehensive test cases (219 new lines)
+
+### Key Changes
+
+- **Format Detection**: Added `isinstance(conditions, list)` check to determine condition data structure type
+- **List Format Handling**: Filters conditions by 'section' field to extract long_entry, short_entry, long_exit, and short_exit conditions
+- **Dictionary Format Support**: Maintains backward compatibility with legacy `.get()` approach for old dictionary-based conditions
+- **Comprehensive Testing**: Added tests for both formats, empty conditions, and mixed section types to prevent future regressions
+
+## How to Use
+
+This fix is transparent to users - backtests will now execute successfully regardless of which format strategy conditions are stored in:
+
+1. **New Format (Current)**: Strategies saved through the Strategy Builder store conditions as a list of objects with a 'section' field
+2. **Legacy Format**: Older strategies with dictionary-based conditions continue to work without modification
+3. **No Migration Required**: Existing data works automatically without database updates
+
+## Configuration
+
+No configuration changes required. The fix automatically detects and handles both data formats.
+
+## Testing
+
+Run the following commands to validate the fix:
+
+```bash
+cd app/server && uv run pytest tests/test_backtest_executor.py::TestConditionFormatHandling -v
+cd app/server && uv run pytest tests/test_backtest_executor.py -v
+cd app/server && uv run pytest
+cd app/client && npm run build
+```
+
+## Notes
+
+- The bug occurred because the strategy data model was updated to use a list-based format with 'section' fields, but the backtest execution code wasn't updated to match
+- The validation logic in `validate_strategy_for_execution()` already handled both formats correctly; this fix mirrors that approach in the execution path
+- Four condition section types are supported: 'long_entry', 'short_entry', 'long_exit', 'short_exit'
+- No performance impact - format detection happens once per backtest execution

--- a/playwright-mcp-config.json
+++ b/playwright-mcp-config.json
@@ -6,7 +6,7 @@
     },
     "contextOptions": {
       "recordVideo": {
-        "dir": "/home/ubuntu/algotrading/trees/4620e8ed/videos",
+        "dir": "/home/ubuntu/algotrading/trees/f58bdd9c/videos",
         "size": {
           "width": 1920,
           "height": 1080

--- a/specs/issue-116-adw-f58bdd9c-sdlc_planner-backtest-conditions-data-structure.md
+++ b/specs/issue-116-adw-f58bdd9c-sdlc_planner-backtest-conditions-data-structure.md
@@ -1,0 +1,91 @@
+# Bug: Backtest Conditions Data Structure Fix
+
+## Metadata
+issue_number: `116`
+adw_id: `f58bdd9c`
+issue_json: `{"number":116,"title":"Bug backtest fix","body":"/bug \n\nAdw_sdlc_iso\n\n Backtests fail with 'list' object has no attribute 'get' error at line 495 in backtest_executor.py. This is a separate, pre-existing bug where the strategy conditions are returned as a list instead of a dictionary with 'long_entry' and 'short_entry' keys. - - \nThis is NOT caused by the timezone fix.\nResolution: Fix the strategy conditions data structure handling in the backtest executor to handle both list and dictionary formats, or ensure the API returns conditions in the expected dictionary format.\n\n"}`
+
+## Bug Description
+Backtests fail during execution with an `AttributeError: 'list' object has no attribute 'get'` error at line 495 in `app/server/core/backtest_executor.py`. The bug occurs because the strategy conditions are stored as a list of condition objects with a 'section' field (new format) in the database, but the backtest executor expects conditions to be a dictionary with 'long_entry' and 'short_entry' keys (legacy format).
+
+## Problem Statement
+The backtest executor's `_execute_backtest` method at lines 493-498 attempts to call `.get()` on the conditions object, assuming it's a dictionary. However, when strategies are saved through the current API (via `strategy_service.py`), conditions are stored as a list of `StrategyCondition` objects that have a 'section' field to categorize them. This format mismatch causes backtests to immediately fail when trying to extract entry conditions.
+
+## Solution Statement
+Update the backtest executor's `_execute_backtest` method to handle both the legacy dictionary format and the new list format for strategy conditions. The fix will check the type of the conditions object and extract entry/exit conditions appropriately based on the format detected. This approach maintains backward compatibility with any legacy strategies stored in the old format while supporting the current data structure.
+
+## Steps to Reproduce
+1. Create a strategy in the Strategy Builder with at least one entry condition
+2. Save the strategy to the database (conditions are stored as a list with 'section' fields)
+3. Create a backtest configuration using that strategy
+4. Start the backtest execution
+5. Observe the error: `AttributeError: 'list' object has no attribute 'get'` at line 495 in backtest_executor.py
+6. The backtest fails immediately without processing any candles
+
+## Root Cause Analysis
+The root cause is a data structure inconsistency between how strategies are saved and how they are read during backtest execution:
+
+1. **Current Save Format (strategy_service.py)**: Conditions are saved as a list of dictionaries, where each condition object has a 'section' field (values: 'long_entry', 'short_entry', 'long_exit', 'short_exit') to categorize it. This is the StrategyCondition model format.
+
+2. **Expected Read Format (backtest_executor.py line 494-498)**: The executor expects conditions to be a dictionary with top-level keys like `{'long_entry': [...], 'short_entry': [...], 'long_exit': [...], 'short_exit': [...]}`.
+
+3. **Validation Logic Handles Both**: The `validate_strategy_for_execution` method (lines 114-123) correctly handles both formats by checking `isinstance(conditions, list)`, but the main execution logic does not have this check.
+
+The bug was introduced when the strategy data model was updated to use a list-based format with 'section' fields, but the backtest execution code was not updated to match.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- **app/server/core/backtest_executor.py** (lines 493-498) - Contains the bug where conditions.get() is called on a list. The `_execute_backtest` method needs to be updated to detect and handle both data formats, similar to the validation method at lines 114-123.
+
+- **app/server/core/data_models.py** - Contains the StrategyCondition Pydantic model definition to understand the 'section' field structure.
+
+- **app/server/core/strategy_service.py** (lines 48-49, 91-100) - Shows how conditions are saved as a list and provides the `_db_row_to_strategy` function that demonstrates the expected data structure.
+
+- **app/server/tests/test_backtest_executor.py** (lines 89-147) - Contains existing validation tests that show both data formats are expected. New tests should be added to verify the execution logic handles both formats.
+
+### New Files
+None required - this is a data structure handling fix in existing code.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### 1. Update backtest_executor.py to handle both condition formats
+- Read `app/server/core/backtest_executor.py` and locate the `_execute_backtest` method around lines 493-498
+- Add format detection logic similar to the `validate_strategy_for_execution` method (lines 114-123)
+- Replace the direct `conditions.get()` calls with a type check:
+  - If `isinstance(conditions, list)`: filter by 'section' field to extract conditions
+  - If `isinstance(conditions, dict)`: use the existing `.get()` approach for backward compatibility
+- Extract long_entry_conditions, short_entry_conditions, long_exit_conditions, and short_exit_conditions using the appropriate method for each format
+- Ensure the extracted conditions are always lists (or empty lists if none exist)
+
+### 2. Add comprehensive unit tests for both condition formats
+- Read `app/server/tests/test_backtest_executor.py` to understand the test structure
+- Add a new test class `TestConditionFormatHandling` with the following test cases:
+  - `test_execute_backtest_with_legacy_dict_format` - Verify backtest executes successfully with old dictionary format
+  - `test_execute_backtest_with_new_list_format` - Verify backtest executes successfully with new list format (primary test for this bug fix)
+  - `test_execute_backtest_with_empty_conditions_list` - Verify graceful handling of empty conditions
+  - `test_execute_backtest_with_mixed_section_types` - Verify all four section types are extracted correctly from list format
+- Use mocking to simulate the full backtest execution flow without requiring a real database
+
+### 3. Run validation commands
+- Execute the validation commands listed below to ensure the bug is fixed with zero regressions
+- Verify both unit tests and any integration tests pass
+- Confirm the build completes without errors
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `cd app/server && uv run pytest tests/test_backtest_executor.py::TestConditionFormatHandling -v` - Run new tests for condition format handling
+- `cd app/server && uv run pytest tests/test_backtest_executor.py::TestStrategyValidation -v` - Verify validation tests still pass
+- `cd app/server && uv run pytest tests/test_backtest_executor.py -v` - Run all backtest executor tests to ensure no regressions
+- `cd app/server && uv run pytest` - Run server tests to validate the bug is fixed with zero regressions
+- `cd app/client && npm run build` - Run frontend build to validate the bug is fixed with zero regressions
+
+## Notes
+- This bug affects all backtests created after the strategy data model was updated to use the list-based format with 'section' fields
+- The fix maintains backward compatibility with any legacy strategies that might still use the dictionary format
+- The validation logic in `validate_strategy_for_execution` already handles both formats correctly (lines 114-123), so the fix mirrors that approach
+- The four condition section types are: 'long_entry', 'short_entry', 'long_exit', 'short_exit'
+- After this fix, backtests should execute successfully regardless of which format the strategy conditions are stored in
+- No database migration is required - this is purely a code logic fix to handle existing data correctly


### PR DESCRIPTION
## Summary

Fixed the backtest conditions data structure issue where backtests fail with `'list' object has no attribute 'get'` error at line 495 in backtest_executor.py. This is a pre-existing bug where strategy conditions are returned as a list instead of a dictionary with 'long_entry' and 'short_entry' keys.

## Implementation Plan

See [implementation plan](specs/issue-116-adw-f58bdd9c-sdlc_planner-backtest-conditions-data-structure.md) for details.

## Changes Made

- Added plan for fixing strategy conditions data structure handling in backtest executor
- Solution will handle both list and dictionary formats, or ensure API returns conditions in expected dictionary format

## ADW Tracking

ADW ID: f58bdd9c

Closes #116